### PR TITLE
[LAUNCH] - Update initialization template to not use Array.prototype.slice.call

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -226,7 +226,10 @@ setInWindow("mParticle", mParticleObject, true);
             if (base) {
                 method = base + '.' + method;
             }
-            var args = callInWindow("Array.prototype.slice.call", arguments);
+            var args = [];
+            for (var i = 0; i < arguments.length; i++) {
+              args.push(arguments[i]);
+            }
             args.unshift(method);
             mParticleObject.config.rq.push(args);
         };


### PR DESCRIPTION
Background:
We were seeing errors in the GTM console "Tag failed "access_globals" permission check: Prohibited execute on global variable: Array.prototype.slice.call for both custom and screen view events"

This update should resolve that issue while keeping the same functionality.