### PR TITLE
[LAUNCH] - Update log level order

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -59,12 +59,12 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": false,
         "selectItems": [
           {
-            "value": "verbose",
-            "displayValue": "Verbose"
-          },
-          {
             "value": "warning",
             "displayValue": "Warning"
+          },
+          {
+            "value": "verbose",
+            "displayValue": "Verbose"
           },
           {
             "value": "none",
@@ -75,7 +75,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "type": "LABEL",
-        "name": "label2a",
+        "name": "flagsLabel",
         "displayName": "Flags"
       },
       {


### PR DESCRIPTION
Summary

Fixing the log level order so the default value is warning rather than verbose. This should clean up the noisy logs when using GTM.